### PR TITLE
Add `dev-tools` submodule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+dev-tools/.clang-format

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Bazel output directories.
+bazel-bin
+bazel-out
+bazel-stout-flags
+bazel-testlogs
+        
+# emacs temporary files.
+*~
+
+# Temporary files from VScode.
+.vs
+.vscode
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dev-tools"]
+	path = dev-tools
+	url = https://github.com/3rdparty/dev-tools.git


### PR DESCRIPTION
This PR adds `dev-tools` submodule, the symlink to `.clang-format` file ( `3rdparty/dev-tools/.clang-format` ) and `.gitignore` file which excludes output dirs, temporary emacs files and temporary VScode files.