### PR TITLE
Support unquotted and quotted string values

### DIFF
--- a/stout/flags.cc
+++ b/stout/flags.cc
@@ -1,6 +1,7 @@
 #include "stout/flags.h"
 
 #include "absl/strings/ascii.h"
+#include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "glog/logging.h"
 
@@ -186,7 +187,11 @@ void Parser::Parse(
           + "': missing value");
       continue;
     } else {
-      text = value.value();
+      if (field->type() != google::protobuf::FieldDescriptor::TYPE_STRING) {
+        text = value.value();
+      } else {
+        text = "'" + absl::CEscape(value.value()) + "'";
+      }
     }
 
     CHECK(text);


### PR DESCRIPTION
This PR enables supporting the following cases:
```
./program --foo="hello world"
./program --foo='hello world'
./program --foo="hello"
./program --foo='hello'
./program --foo=hello
```