### PR TITLE
Introduce parsing subcommand flags

### DIFF
--- a/stout/flags.h
+++ b/stout/flags.h
@@ -9,6 +9,7 @@
 #include "google/protobuf/io/tokenizer.h"
 #include "google/protobuf/text_format.h"
 #include "stout/v1/flag.pb.h"
+#include "stout/v1/subcommand.pb.h"
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/stout/v1/BUILD.bazel
+++ b/stout/v1/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "flag_proto",
-    srcs = [":flag.proto"],
+    srcs = [
+        ":flag.proto",
+        ":subcommand.proto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         # Well known protos should be included as deps in the

--- a/stout/v1/subcommand.proto
+++ b/stout/v1/subcommand.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package stout.v1;
+
+import "google/protobuf/descriptor.proto";
+
+message Subcommand {
+  repeated string names = 1;
+  repeated string deprecated_names = 2;
+  string help = 3;
+  // TODO: bool deprecated = 4;
+}
+
+extend google.protobuf.FieldOptions {
+  optional Subcommand subcommand = 1001;
+}

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -31,6 +31,7 @@ cc_test(
         "missing_flag_name.cc",
         "overload_parsing.cc",
         "parse.cc",
+        "subcommand_flags.cc",
         "validate.cc",
     ],
     deps = [

--- a/test/duplicate_flag_name.cc
+++ b/test/duplicate_flag_name.cc
@@ -11,8 +11,8 @@ TEST(FlagsTest, DuplicateFlagName) {
         auto builder = stout::flags::Parser::Builder(&duplicate_flag_name);
         builder.Build();
       }(),
-      "Encountered duplicate flag name 'same' for "
-      "field 'test.DuplicateFlagName.s2'");
+      "Encountered duplicate flag name 'same' for message "
+      "'test.DuplicateFlagName'");
 }
 
 TEST(FlagsTest, DuplicateSucceed) {

--- a/test/environment_variables.cc
+++ b/test/environment_variables.cc
@@ -29,7 +29,6 @@ TEST(FlagsTest, EnvironmentVariableString) {
   std::array arguments = {
       "program",
       "--bar",
-      "one",
   };
 
   int argc = arguments.size();
@@ -44,10 +43,9 @@ TEST(FlagsTest, EnvironmentVariableString) {
   unsetenv(env_name);
 
   EXPECT_TRUE(flags.bar());
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags.foo());
   EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
 }
 
 TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
@@ -59,7 +57,6 @@ TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -92,7 +89,6 @@ TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -124,7 +120,6 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   std::array arguments = {
       "program",
       "--foo='hello'",
-      "one",
   };
 
   int argc = arguments.size();
@@ -138,9 +133,8 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   parser.Parse(&argc, &argv);
   unsetenv(env_name);
 
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags._s());
   EXPECT_EQ("'hello'", flags.foo());
   EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
 }

--- a/test/missing_flag_name.cc
+++ b/test/missing_flag_name.cc
@@ -23,3 +23,25 @@ TEST(FlagsTest, MissingFlagHelp) {
       "Missing flag 'help' for "
       "field 'test.MissingFlagHelp.s'");
 }
+
+TEST(FlagsTest, MissingSubcommandFlagName) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagsWithoutName missing_flag_name;
+        auto builder = stout::flags::Parser::Builder(&missing_flag_name);
+        builder.Build();
+      }(),
+      "Missing at least one flag name in 'names' for "
+      "field 'test.SubcommandFlagsWithoutName.build'");
+}
+
+TEST(FlagsTest, MissingSubcommandFlagHelp) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagsWithoutHelp missing_flag_help;
+        auto builder = stout::flags::Parser::Builder(&missing_flag_help);
+        builder.Build();
+      }(),
+      "Missing flag 'help' for "
+      "field 'test.SubcommandFlagsWithoutHelp.info_flag'");
+}

--- a/test/missing_flag_name.cc
+++ b/test/missing_flag_name.cc
@@ -24,24 +24,24 @@ TEST(FlagsTest, MissingFlagHelp) {
       "field 'test.MissingFlagHelp.s'");
 }
 
-TEST(FlagsTest, MissingSubcommandFlagName) {
+TEST(FlagsTest, MissingSubcommandName) {
   EXPECT_DEATH(
       []() {
-        test::SubcommandFlagsWithoutName missing_flag_name;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_name);
+        test::FlagsWithSubcommandMissingName flags;
+        auto builder = stout::flags::Parser::Builder(&flags);
         builder.Build();
       }(),
-      "Missing at least one flag name in 'names' for "
-      "field 'test.SubcommandFlagsWithoutName.build'");
+      "Missing at least one subcommand name in 'names' for "
+      "field 'test.FlagsWithSubcommandMissingName.build'");
 }
 
-TEST(FlagsTest, MissingSubcommandFlagHelp) {
+TEST(FlagsTest, MissingSubcommandHelp) {
   EXPECT_DEATH(
       []() {
-        test::SubcommandFlagsWithoutHelp missing_flag_help;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_help);
+        test::FlagsWithSubcommandMissingHelp flags;
+        auto builder = stout::flags::Parser::Builder(&flags);
         builder.Build();
       }(),
-      "Missing flag 'help' for "
-      "field 'test.SubcommandFlagsWithoutHelp.info_flag'");
+      "Missing subcommand 'help' for "
+      "field 'test.FlagsWithSubcommandMissingHelp.info_subcommand'");
 }

--- a/test/parse.cc
+++ b/test/parse.cc
@@ -164,9 +164,7 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   std::array arguments = {
       "/path/to/program",
       "--foo='hello world'",
-      "one",
       "--bar",
-      "two",
   };
 
   int argc = arguments.size();
@@ -177,11 +175,9 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ("'hello world'", flags.foo());
 
-  EXPECT_EQ(3, argc);
+  EXPECT_EQ(1, argc);
 
   EXPECT_EQ("/path/to/program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
-  EXPECT_EQ("two", argv[2]);
 }
 
 TEST(FlagsTest, UnknownNonNegatedFlag) {

--- a/test/subcommand_flags.cc
+++ b/test/subcommand_flags.cc
@@ -1,3 +1,5 @@
+#include <array>
+
 #include "gtest/gtest.h"
 #include "stout/flags.h"
 #include "test/test.pb.h"
@@ -9,8 +11,8 @@ TEST(FlagsTest, MissingSubcommandExtension) {
         auto builder = stout::flags::Parser::Builder(&flag);
         builder.Build();
       }(),
-      "Every field of the 'oneof subcommand' must have"
-      " .stout.v1.subcommand. extension.");
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
 }
 
 TEST(FlagsTest, IncorrectSubcommandExtension) {
@@ -20,8 +22,8 @@ TEST(FlagsTest, IncorrectSubcommandExtension) {
         auto builder = stout::flags::Parser::Builder(&flag);
         builder.Build();
       }(),
-      ".stout.v1.subcommand. extension should be inside only"
-      " a 'oneof subcommand' field.");
+      "stout.v1.subcommand option should be annotated on fields"
+      " that are only inside 'oneof subcommand'");
 }
 
 TEST(FlagsTest, IncorrectOneofName) {
@@ -32,7 +34,7 @@ TEST(FlagsTest, IncorrectOneofName) {
         builder.Build();
       }(),
       "'oneof' field must have 'subcommand' name. "
-      "Other names are illegal.");
+      "Other names are illegal");
 }
 
 TEST(FlagsTest, SubcommandFlagExtension) {
@@ -42,6 +44,317 @@ TEST(FlagsTest, SubcommandFlagExtension) {
         auto builder = stout::flags::Parser::Builder(&flag);
         builder.Build();
       }(),
-      "Every field of the 'oneof subcommand' must have"
-      " .stout.v1.subcommand. extension.");
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFields) {
+  EXPECT_DEATH(
+      []() {
+        test::DuplicateSubcommandFields flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Encountered duplicate subcommand name 'build'"
+      " for message 'test.DuplicateSubcommandFields'");
+}
+
+TEST(FlagsTest, SubcommandAndUnknownArguments) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+      "--",
+      "some",
+      "unknown",
+      "arguments",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(4, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("some", argv[1]);
+  EXPECT_EQ("unknown", argv[2]);
+  EXPECT_EQ("arguments", argv[3]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ("hello world", flags.info_subcommand().info());
+}
+
+TEST(FlagsTest, DuplicateSubcommands) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+      "info_subcommand",
+      "--info=oops",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlags) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered duplicate flag 'other_flag'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
+  test::DuplicateEnclosingFlagName flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--other_flag=1",
+      "build",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ(1, flags.other_flag());
+  EXPECT_EQ(2, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "info_subcommand",
+      "--info=hello",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "build",
+      "--other_flag=1",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub1().has_build());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ(1, flags.sub1().build().other_flag());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "info_subcommand",
+      "--info=ciao",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_build());
+  EXPECT_TRUE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ("ciao", flags.sub1().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "info_subcommand",
+      "--info=some info",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_FALSE(flags.sub2().has_build());
+  EXPECT_TRUE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ("some info", flags.sub2().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub2().has_build());
+  EXPECT_FALSE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ(13, flags.sub2().build().other_flag());
 }

--- a/test/subcommand_flags.cc
+++ b/test/subcommand_flags.cc
@@ -1,0 +1,47 @@
+#include "gtest/gtest.h"
+#include "stout/flags.h"
+#include "test/test.pb.h"
+
+TEST(FlagsTest, MissingSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagsWithoutExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must have"
+      " .stout.v1.subcommand. extension.");
+}
+
+TEST(FlagsTest, IncorrectSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithIncorrectExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      ".stout.v1.subcommand. extension should be inside only"
+      " a 'oneof subcommand' field.");
+}
+
+TEST(FlagsTest, IncorrectOneofName) {
+  EXPECT_DEATH(
+      []() {
+        test::IncorrectOneofName flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "'oneof' field must have 'subcommand' name. "
+      "Other names are illegal.");
+}
+
+TEST(FlagsTest, SubcommandFlagExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must have"
+      " .stout.v1.subcommand. extension.");
+}

--- a/test/test.proto
+++ b/test/test.proto
@@ -141,16 +141,16 @@ message InfoFlag {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-message SubcommandFlagsWithoutName {
+message FlagsWithSubcommandMissingName {
   oneof subcommand {
     BuildFlag build = 1 [
       (stout.v1.subcommand) = {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 2 [
+    InfoFlag info_subcommand = 2 [
       (stout.v1.subcommand) = {
-        names: [ "info_flag" ]
+        names: [ "info_subcommand" ]
         help: "help"
       }
     ];
@@ -159,7 +159,7 @@ message SubcommandFlagsWithoutName {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-message SubcommandFlagsWithoutHelp {
+message FlagsWithSubcommandMissingHelp {
   oneof subcommand {
     BuildFlag build = 1 [
       (stout.v1.subcommand) = {
@@ -167,9 +167,9 @@ message SubcommandFlagsWithoutHelp {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 2 [
+    InfoFlag info_subcommand = 2 [
       (stout.v1.subcommand) = {
-        names: [ "info_flag" ]
+        names: [ "info_subcommand" ]
       }
     ];
   }
@@ -192,7 +192,7 @@ message SubcommandFlagsWithoutExtension {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 3;
+    InfoFlag info_subcommand = 3;
   }
 }
 
@@ -213,9 +213,9 @@ message FlagsWithIncorrectExtension {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 3 [
+    InfoFlag info_subcommand = 3 [
       (stout.v1.subcommand) = {
-        names: [ "info_flag" ]
+        names: [ "info_subcommand" ]
         help: "help"
       }
     ];
@@ -232,9 +232,9 @@ message IncorrectOneofName {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 2 [
+    InfoFlag info_subcommand = 2 [
       (stout.v1.subcommand) = {
-        names: [ "info_flag" ]
+        names: [ "info_subcommand" ]
         help: "help"
       }
     ];
@@ -251,9 +251,172 @@ message SubcommandFlagExtension {
         help: "help"
       }
     ];
-    InfoFlag info_flag = 2 [
+    InfoFlag info_subcommand = 2 [
       (stout.v1.subcommand) = {
-        names: [ "info_flag" ]
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SimpleSubcommandSucceed {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b", "bb" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message ComplicatedSubcommandMessage {
+  string flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "flag" ]
+      help: "help"
+    }
+  ];
+
+  string other = 2 [
+    (stout.v1.flag) = {
+      names: [ "other" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    SubcommandSubMessage1 sub1 = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "sub1" ]
+        help: "help"
+      }
+    ];
+    SubcommandSubMessage2 sub2 = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "sub2" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage1 {
+  string another = 1 [
+    (stout.v1.flag) = {
+      names: [ "another" ]
+      help: "help"
+    }
+  ];
+
+  int32 num = 2 [
+    (stout.v1.flag) = {
+      names: [ "num" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage2 {
+  string s = 1 [
+    (stout.v1.flag) = {
+      names: [ "s" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateEnclosingFlagName {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateSubcommandFields {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
         help: "help"
       }
     ];

--- a/test/test.proto
+++ b/test/test.proto
@@ -4,6 +4,7 @@ package test;
 
 import "google/protobuf/duration.proto";
 import "stout/v1/flag.proto";
+import "stout/v1/subcommand.proto";
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -114,6 +115,149 @@ message DuplicateFlagsDeath {
       help: "help"
     }
   ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message BuildFlag {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message InfoFlag {
+  string info = 1 [
+    (stout.v1.flag) = {
+      names: [ "info" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagsWithoutName {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_flag" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagsWithoutHelp {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_flag" ]
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagsWithoutExtension {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 3;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithIncorrectExtension {
+  bool b = 1 [
+    (stout.v1.subcommand) = {
+      names: [ "build" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_flag" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message IncorrectOneofName {
+  oneof other {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_flag" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagExtension {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.flag) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_flag = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_flag" ]
+        help: "help"
+      }
+    ];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Created `subcommand.proto` with the message `Subcommand`. This message,
like `Flag` message in `stout/v1/flag.proto` is extended from
google.protobuf.FieldOptions message (google/protobuf/descriptor.proto).
Added the support for making sure that if someone gives some message
for "building" all of the (stout.v1.subcommand) will be inside `oneof
subcommand` field. Also added some tests.