### PR TITLE
Introduce parsing positional arguments

### DIFF
--- a/stout/flags.h
+++ b/stout/flags.h
@@ -9,6 +9,7 @@
 #include "google/protobuf/io/tokenizer.h"
 #include "google/protobuf/text_format.h"
 #include "stout/v1/flag.pb.h"
+#include "stout/v1/positional_argument.pb.h"
 
 ////////////////////////////////////////////////////////////////////////
 

--- a/stout/v1/BUILD.bazel
+++ b/stout/v1/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "flag_proto",
-    srcs = [":flag.proto"],
+    srcs = [
+        ":flag.proto",
+        ":positional_argument.proto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         # Well known protos should be included as deps in the

--- a/stout/v1/positional_argument.proto
+++ b/stout/v1/positional_argument.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package stout.v1;
+
+import "google/protobuf/descriptor.proto";
+
+message Argument {
+  repeated string names = 1;
+  repeated string deprecated_names = 2;
+  string help = 3;
+  bool required = 4;
+  uint32 position = 5;
+}
+
+extend google.protobuf.FieldOptions {
+  optional Argument argument = 1002;
+}

--- a/test/test.proto
+++ b/test/test.proto
@@ -4,6 +4,7 @@ package test;
 
 import "google/protobuf/duration.proto";
 import "stout/v1/flag.proto";
+import "stout/v1/positional_argument.proto";
 
 ///////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Added `positional_argument.proto` and make it build via `proto_library`
rule in the `stout/v1/BUILD.bazel`.