### PR TITLE
Stop skipping builds for markdown changes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-# Workflow for building and testing flags on macOS, Ubuntu and Windows.  
+# Workflow for building and testing flags on macOS, Ubuntu and Windows.
 name: Build and Run all tests
 
 # We use action's triggers 'push' and 'pull_request'.
@@ -10,12 +10,10 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"   
-  
+    branches:
+      - "**"
+
 jobs:
   build-and-test:
     name: Build and Test
@@ -37,10 +35,10 @@ jobs:
             --spawn_strategy=local \
             -c dbg \
             --strip="never" \
-            :flags       
+            :flags
 
       - name: Test
-        run: | 
+        run: |
           bazel test \
             --spawn_strategy=local \
             -c dbg \
@@ -52,4 +50,4 @@ jobs:
 
       - name: Debug using tmate (if failure)
         if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3  
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -9,11 +9,9 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"   
+    branches:
+      - "**"
 
 jobs:
   check_code_style:
@@ -21,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        
+
     steps:
       # We should checkout the repo with submodules
-      # cause we need to have symlink to 
+      # cause we need to have symlink to
       # dev-tools/.clang-format file for all code
-      # style checks.   
+      # style checks.
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
@@ -36,7 +34,7 @@ jobs:
       # is in `./dev-tools/check-code-style` submodule's
       # directory from the current submodule commit.
       - uses: ./dev-tools/check-code-style
-        with: 
+        with:
           os: ${{matrix.os}}
 
       - name: Debug using tmate (if failure)


### PR DESCRIPTION
I still love the idea of shedding unnecessary build load and avoiding
unnecessary merge latency, but the implementation I submitted is quite
brittle:
![Mergequeue queued forever](https://user-images.githubusercontent.com/19922103/161862085-8c7c3b4e-27fe-48d1-b593-af770d118ed2.png)

Waiting for tests before merging is much less painful now that we're
using mergequeue, so let's remove the nobuilds to keep merging simple
and robust (though not as fast as might be ideal).
