### PR TITLE
Update to a newer abseil release

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -14,9 +14,9 @@ def deps(repo_mapping = {}):
     maybe(
         http_archive,
         name = "com_google_absl",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/98eb410c93ad059f9bba1bf43f5bb916fc92a5ea.zip"],
-        strip_prefix = "abseil-cpp-98eb410c93ad059f9bba1bf43f5bb916fc92a5ea",
-        sha256 = "aabf6c57e3834f8dc3873a927f37eaf69975d4b28117fc7427dfb1c661542a87",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+        strip_prefix = "abseil-cpp-20211102.0",
+        sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
         repo_mapping = repo_mapping,
     )
 


### PR DESCRIPTION
The current release is over 2 years old, probably copied from
https://github.com/abseil/abseil-cpp/blob/master/FAQ.md#what-is-live-at-head-and-how-do-i-do-it

I think this newer release is required to propagate the latest version
of this repo to other repos without introducing a conflicting and
too-old version of abseil.
