### PR TITLE
Introduce subcommands

### DIFF
--- a/stout/flags.cc
+++ b/stout/flags.cc
@@ -18,63 +18,185 @@ namespace stout::flags {
 
 ////////////////////////////////////////////////////////////////////////
 
-void Parser::AddAllOrExit(google::protobuf::Message* message) {
+void Parser::AddFieldsAndSubcommandsOrExit(google::protobuf::Message* message) {
   const auto* descriptor = message->GetDescriptor();
 
   for (int i = 0; i < descriptor->field_count(); i++) {
     const auto* field = descriptor->field(i);
 
-    const auto& flag = field->options().GetExtension(stout::v1::flag);
+    // We need this descriptor for the subcommand's logic.
+    const google::protobuf::OneofDescriptor* oneof =
+        field->real_containing_oneof();
 
-    if (flag.names().empty()) {
-      std::cerr
-          << "Missing at least one flag name in 'names' for field '"
-          << field->full_name() << "'"
-          << std::endl;
-      std::exit(1);
-    }
+    // Check if the current field of the message is in 'oneof'.
+    if (oneof != nullptr) {
+      // Check if the name of 'oneof' is 'subcommand'. If no then exit
+      // with an error.
+      if (oneof->name() != "subcommand") {
+        std::cerr << "'oneof' field must have 'subcommand' name. "
+                  << "Other names are illegal"
+                  << std::endl;
+        exit(1);
+      } else {
+        // Subcommands must have stout.v1.subcommand option.
+        if (!field->options().HasExtension(stout::v1::subcommand)) {
+          std::cerr << "Every field of the 'oneof subcommand' must "
+                       "be annotated with a stout.v1.subcommand option"
+                    << std::endl;
+          exit(1);
+        } else {
+          // Check for missing 'names' and 'help'.
+          const auto& subcommand =
+              field->options().GetExtension(stout::v1::subcommand);
 
-    if (flag.help().empty()) {
-      std::cerr
-          << "Missing flag 'help' for field '" << field->full_name() << "'"
-          << std::endl;
-      std::exit(1);
-    }
+          if (subcommand.names().empty()) {
+            std::cerr
+                << "Missing at least one subcommand name in 'names' "
+                << "for field '" << field->full_name() << "'"
+                << std::endl;
+            std::exit(1);
+          }
 
-    for (const auto& name : flag.names()) {
-      AddOrExit(name, field, message);
-    }
+          if (subcommand.help().empty()) {
+            std::cerr
+                << "Missing subcommand 'help' for field '"
+                << field->full_name() << "'"
+                << std::endl;
+            std::exit(1);
+          }
 
-    for (const auto& name : flag.deprecated_names()) {
-      AddOrExit(name, field, message);
+          for (const auto& name : subcommand.names()) {
+            auto [_, inserted] = subcommand_fields_.emplace(name, field);
+
+            if (!inserted) {
+              std::cerr << "Encountered duplicate subcommand name "
+                        << "'" << name << "' for message '"
+                        << message->GetTypeName() << "'"
+                        << std::endl;
+              std::exit(1);
+            }
+          }
+
+          for (const auto& name : subcommand.deprecated_names()) {
+            auto [_, inserted] = subcommand_fields_.emplace(name, field);
+
+            if (!inserted) {
+              std::cerr << "Encountered duplicate (deprecated) subcommand name "
+                        << "'" << name << "' for message '"
+                        << message->GetTypeName() << "'"
+                        << std::endl;
+              std::exit(1);
+            }
+          }
+
+          // Create nested parser and store it to the 'nested_parsers_'.
+          auto [_, inserted] = nested_parsers_.emplace(
+              field,
+              std::make_unique<Parser>(
+                  Parser::Builder(
+                      message->GetReflection()->MutableMessage(message, field),
+                      true)
+                      .Build()));
+
+          CHECK(inserted);
+        }
+      }
+    } else {
+      if (field->options().HasExtension(stout::v1::subcommand)) {
+        std::cerr << "stout.v1.subcommand option should be annotated"
+                  << " on fields that are only inside 'oneof subcommand'"
+                  << std::endl;
+        exit(1);
+      }
+
+      const auto& flag = field->options().GetExtension(stout::v1::flag);
+
+      if (flag.names().empty()) {
+        std::cerr
+            << "Missing at least one flag name in 'names' for field '"
+            << field->full_name() << "'"
+            << std::endl;
+        std::exit(1);
+      }
+
+      if (flag.help().empty()) {
+        std::cerr
+            << "Missing flag 'help' for field '"
+            << field->full_name() << "'"
+            << std::endl;
+        std::exit(1);
+      }
+
+      for (const auto& name : flag.names()) {
+        auto [_, inserted] = fields_.emplace(name, field);
+
+        if (!inserted) {
+          std::cerr << "Encountered duplicate flag name "
+                    << "'" << name << "' for message '"
+                    << message->GetTypeName() << "'"
+                    << std::endl;
+          std::exit(1);
+        }
+      }
+
+      for (const auto& name : flag.deprecated_names()) {
+        auto [_, inserted] = fields_.emplace(name, field);
+
+        if (!inserted) {
+          std::cerr << "Encountered duplicate (deprecated) flag name "
+                    << "'" << name << "' for message '"
+                    << message->GetTypeName() << "'"
+                    << std::endl;
+          std::exit(1);
+        }
+      }
     }
   }
 }
 
 ////////////////////////////////////////////////////////////////////////
 
-void Parser::AddOrExit(
-    const std::string& name,
-    const google::protobuf::FieldDescriptor* field,
-    google::protobuf::Message* message) {
-  auto [_, inserted] = fields_.emplace(name, field);
-
-  if (!inserted) {
-    std::cerr
-        << "Encountered duplicate flag name '" << name << "' "
-        << "for field '" << field->full_name() << "'"
-        << std::endl;
-    std::exit(1);
+Parser* Parser::TryLookupParserForSubcommand(const std::string& name) {
+  auto iterator = subcommand_fields_.find(name);
+  if (iterator != subcommand_fields_.end()) {
+    const google::protobuf::FieldDescriptor* field = iterator->second;
+    CHECK_NE(nested_parsers_.count(field), 0);
+    return nested_parsers_[field].get();
+  } else {
+    return nullptr;
   }
+}
 
-  messages_.emplace(field, message);
+////////////////////////////////////////////////////////////////////////
+
+google::protobuf::Message* Parser::GetMessageForField(
+    const google::protobuf::FieldDescriptor* field) {
+  if (field->containing_type() == standard_flags_->GetDescriptor()) {
+    return standard_flags_.get();
+  } else {
+    return CHECK_NOTNULL(message_);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+google::protobuf::Message* Parser::GetMessageForSubcommand(
+    const std::string& name) {
+  // NOTE: precondition is that this is a valid subcommand!
+  CHECK_NE(subcommand_fields_.count(name), 0);
+  const google::protobuf::FieldDescriptor* field = subcommand_fields_[name];
+  return CHECK_NOTNULL(message_)
+      ->GetReflection()
+      ->MutableMessage(message_, field);
 }
 
 ////////////////////////////////////////////////////////////////////////
 
 void Parser::Parse(int* argc, const char*** argv) {
-  // Grab the program name from argv, without removing it.
-  program_name_ = *argc > 0
+  // Save the command. For the top-level parser this will be the
+  // executable "basename". For nested parsers this will be the
+  // subcommand name.
+  command_ = *argc > 0
       ? std::filesystem::path((*argv)[0]).filename().string()
       : "";
 
@@ -99,8 +221,49 @@ void Parser::Parse(int* argc, const char*** argv) {
       break;
     }
 
-    // Skip anything that doesn't look like a flag.
+    // Skip anything that doesn't look like a flag, subcommand or positional
+    // argument.
     if (arg.find("--") != 0) {
+      // Check if it's a subcommand.
+      Parser* parser = TryLookupParserForSubcommand(arg);
+      if (parser != nullptr) {
+        // Keep the number of arguments remained before we call 'nested'
+        // Parse() function including subcommand name.
+        int nested_argc = *argc - i;
+
+        CHECK_GE(nested_argc, 0);
+
+        // Keep subcommand name. Using this pointer we can easily call
+        // Parse(&argc, &argv) function for nested parser.
+        const char** nested_argv = &((*argv)[i]);
+
+        // Current argument is a subcommand. So now we can set
+        // 'google::protobuf::Message*' pointer for nested parser in
+        // order to parse flags for this subcommand.
+        parser->message_ = GetMessageForSubcommand(arg);
+
+        // Parsing arguments for 'nested' parser.
+        parser->Parse(&nested_argc, &nested_argv);
+
+        // If after 'nested' parsing of arguments there were not any
+        // arguments after '--' just break.
+        if (nested_argc == 1) {
+          break;
+        } else {
+          // Start at '1' to skip arg_to_parse[0] which is the name
+          // of a subcommand.
+          for (int k = 1; k < nested_argc; ++k) {
+            args.push_back(nested_argv[k]);
+          }
+          break;
+        }
+      } else {
+        // It might be a positional argument or an unknown argument.
+        // If unknown - just exit.
+        std::cerr << "Encountered unknown argument '"
+                  << arg << "'" << std::endl;
+        std::exit(1);
+      }
       args.push_back((*argv)[i]);
       continue;
     }
@@ -272,8 +435,7 @@ void Parser::Parse(
 
     // Parse the value using an overloaded parser if provided.
     if (overload_parsing_.count(field->message_type()) > 0) {
-      CHECK(messages_.count(field) != 0);
-      auto* message = messages_[field];
+      auto* message = GetMessageForField(field);
       std::optional<std::string> error =
           overload_parsing_[field->message_type()](
               text.value(),
@@ -315,7 +477,7 @@ void Parser::Parse(
       if (!text_format_parser.ParseFieldValueFromString(
               text.value(),
               field,
-              messages_[field])) {
+              GetMessageForField(field))) {
         errors.insert(
             "Failed to parse flag '" + non_negated_name
             + "' from normalized value '" + text.value()
@@ -358,14 +520,14 @@ void Parser::Parse(
 
   // Perform validations.
   for (auto& [error, f] : validate_) {
-    if (!f()) {
+    if (!f(CHECK_NOTNULL(message_))) {
       errors.insert(error);
     }
   }
 
   if (!errors.empty()) {
     std::cerr
-        << program_name_ << ": "
+        << command_ << ": "
         << "Failed while parsing and validating flags:"
         << std::endl
         << std::endl;
@@ -383,7 +545,7 @@ void Parser::Parse(
 void Parser::PrintHelp() {
   const int PAD = 5;
 
-  std::string help = "Usage: " + program_name_ + " [...]\n\n";
+  std::string help = "Usage: " + command_ + " [...]\n\n";
 
   std::map<std::string, std::string> col1; // key -> col 1 string.
 

--- a/stout/flags.h
+++ b/stout/flags.h
@@ -100,7 +100,7 @@ class Parser {
       std::function<bool(google::protobuf::Message&)>>
       validate_;
 
-  // Command "basename" extracted from 'argv[0]'
+  // Command "basename" extracted from 'argv[0]'.
   std::string command_;
 
   // Helper struct for storing the parsed "name" and normalized
@@ -127,7 +127,7 @@ class Parser {
 
   // Message to populate when parsing. May be nullptr until parsing
   // for nested parsers because we won't know the pointer until
-  // parsing in the event the parent parse
+  // parsing in the event the parent parse.
   google::protobuf::Message* message_ = nullptr;
 };
 

--- a/stout/flags.h
+++ b/stout/flags.h
@@ -9,6 +9,7 @@
 #include "google/protobuf/io/tokenizer.h"
 #include "google/protobuf/text_format.h"
 #include "stout/v1/flag.pb.h"
+#include "stout/v1/subcommand.pb.h"
 
 ////////////////////////////////////////////////////////////////////////
 
@@ -20,13 +21,14 @@ namespace stout::flags {
 template <typename Flags>
 class ParserBuilder;
 
+
 class Parser {
  public:
   // Returns a builder for a parser based on the specifid flags; see
   // 'ParserBuilder' for more details on what can be modified from the
   // default parser.
   template <typename Flags>
-  static ParserBuilder<Flags> Builder(Flags* flags);
+  static ParserBuilder<Flags> Builder(Flags* flags, bool nested = false);
 
   // Parse flags from 'argc' and 'argv' and modify 'argc' and 'argv'
   // with what ever flags or arguments were not parsed.
@@ -39,17 +41,23 @@ class Parser {
   Parser()
     : standard_flags_(new stout::v1::StandardFlags()) {
     // Add all the "standard flags" first, e.g., --help.
-    AddAllOrExit(standard_flags_.get());
+    AddFieldsAndSubcommandsOrExit(standard_flags_.get());
   }
 
-  // Helper that adds all the flags and their descriptors.
-  void AddAllOrExit(google::protobuf::Message* message);
+  // Helper that fill fields_ and messages_ helpers.
+  void AddFieldsAndSubcommandsOrExit(google::protobuf::Message* message);
 
-  // Helper that adds a flag and it's descriptor.
-  void AddOrExit(
-      const std::string& name,
-      const google::protobuf::FieldDescriptor* field,
-      google::protobuf::Message* message);
+  Parser* TryLookupParserForSubcommand(const std::string& name);
+
+  // Helper that gets 'google::protobuf::Message*' that we want to
+  // populate for the specified field descriptor.
+  google::protobuf::Message* GetMessageForField(
+      const google::protobuf::FieldDescriptor* field);
+
+  // Helper that gets 'google::protobuf::Message*' that we want to
+  // populate for the specified subcommand.
+  google::protobuf::Message* GetMessageForSubcommand(
+      const std::string& name);
 
   // Helper for parsing a normalized form of flags.
   void Parse(
@@ -68,12 +76,12 @@ class Parser {
   // Map from flag name to the field descriptor for the flag.
   std::map<std::string, const google::protobuf::FieldDescriptor*> fields_;
 
-  // Map from the field descriptor to the 'google::protobuf::Message'
-  // that we will use to update the flag value via reflection.
-  std::map<
-      const google::protobuf::FieldDescriptor*,
-      google::protobuf::Message*>
-      messages_;
+  // Map from subcommand name to the field descriptor for the flag.
+  //
+  // NOTE: we need to separate 'fields_' and 'subcommand_fields_' to
+  // support flags and subcommands having the same name.
+  std::map<std::string, const google::protobuf::FieldDescriptor*>
+      subcommand_fields_;
 
   // Map from message descriptors to functions that overload the
   // default parsing for that descriptor.
@@ -87,10 +95,13 @@ class Parser {
 
   // Map from help string to function that we use to validate the
   // parsed flags.
-  std::map<std::string, std::function<bool()>> validate_;
+  std::map<
+      std::string,
+      std::function<bool(google::protobuf::Message*)>>
+      validate_;
 
-  // Name of the program that we extracted from 'argv'.
-  std::string program_name_;
+  // Command "basename" extracted from 'argv[0]'
+  std::string command_;
 
   // Helper struct for storing the parsed "name" and normalized
   // protobuf "text" for a flag. This is used for handling possible
@@ -107,16 +118,36 @@ class Parser {
   // Optional for including all environment variables for parsing
   // with specific prefix.
   std::optional<std::string> environment_variable_prefix_;
+
+  // Map from nested parser to it's all possible names. Depending on the
+  // subcommand defined by the users we can grab specific parser and do
+  // parsing for the next arguments in the command line.
+  std::map<const google::protobuf::FieldDescriptor*, std::unique_ptr<Parser>>
+      nested_parsers_;
+
+  // Message to populate when parsing. May be nullptr until parsing
+  // for nested parsers because we won't know the pointer until
+  // parsing in the event the parent parse
+  google::protobuf::Message* message_ = nullptr;
 };
 
 ////////////////////////////////////////////////////////////////////////
 
+
 template <typename Flags>
 class ParserBuilder {
  public:
-  ParserBuilder(Flags* flags)
-    : flags_(flags) {
-    parser_.AddAllOrExit(flags_);
+  ParserBuilder(Flags* flags, bool nested) {
+    parser_.AddFieldsAndSubcommandsOrExit(flags);
+
+    // When constructing a top-level parser we save the 'flags'
+    // protobuf message to later populate when we call
+    // 'Parse(...)'. We can't save 'flags' for nested parsers because
+    // 'flags' might not be valid if it (or it's "parent") is a oneof
+    // field and thus we need to compute it during the parse.
+    if (!nested) {
+      parser_.message_ = flags;
+    }
   }
 
   // Overloads the parsing of the specified type 'T' with the
@@ -140,8 +171,9 @@ class ParserBuilder {
   ParserBuilder& Validate(std::string&& help, F&& f) {
     parser_.validate_.emplace(
         std::move(help),
-        [f = std::forward<F>(f), flags = flags_]() {
-          return f(*flags);
+        [f = std::forward<F>(f)](auto* message) {
+          return f(
+              *google::protobuf::DynamicCastToGenerated<Flags>(message));
         });
 
     return *this;
@@ -216,7 +248,6 @@ class ParserBuilder {
   }
 
  private:
-  Flags* flags_ = nullptr;
   Parser parser_;
 };
 
@@ -224,8 +255,8 @@ class ParserBuilder {
 
 // Defined after 'ParserBuilder' to deal with circular dependency.
 template <typename Flags>
-ParserBuilder<Flags> Parser::Builder(Flags* flags) {
-  return ParserBuilder<Flags>(flags);
+ParserBuilder<Flags> Parser::Builder(Flags* flags, bool nested) {
+  return ParserBuilder<Flags>(flags, nested);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/stout/v1/BUILD.bazel
+++ b/stout/v1/BUILD.bazel
@@ -3,7 +3,10 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "flag_proto",
-    srcs = [":flag.proto"],
+    srcs = [
+        ":flag.proto",
+        ":subcommand.proto",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         # Well known protos should be included as deps in the

--- a/stout/v1/subcommand.proto
+++ b/stout/v1/subcommand.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package stout.v1;
+
+import "google/protobuf/descriptor.proto";
+
+message Subcommand {
+  repeated string names = 1;
+  repeated string deprecated_names = 2;
+  string help = 3;
+  // TODO: bool deprecated = 4;
+}
+
+extend google.protobuf.FieldOptions {
+  optional Subcommand subcommand = 1001;
+}

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -31,6 +31,7 @@ cc_test(
         "missing_flag_name.cc",
         "overload_parsing.cc",
         "parse.cc",
+        "subcommand_flags.cc",
         "validate.cc",
     ],
     deps = [

--- a/test/duplicate_flag_name.cc
+++ b/test/duplicate_flag_name.cc
@@ -11,8 +11,8 @@ TEST(FlagsTest, DuplicateFlagName) {
         auto builder = stout::flags::Parser::Builder(&duplicate_flag_name);
         builder.Build();
       }(),
-      "Encountered duplicate flag name 'same' for "
-      "field 'test.DuplicateFlagName.s2'");
+      "Encountered duplicate flag name 'same' for message "
+      "'test.DuplicateFlagName'");
 }
 
 TEST(FlagsTest, DuplicateSucceed) {

--- a/test/duplicate_flag_name.cc
+++ b/test/duplicate_flag_name.cc
@@ -8,7 +8,7 @@ TEST(FlagsTest, DuplicateFlagName) {
   EXPECT_DEATH(
       []() {
         test::DuplicateFlagName duplicate_flag_name;
-        auto builder = stout::flags::Parser::Builder(&duplicate_flag_name);
+        auto builder = stout::flags::Parser::Builder(duplicate_flag_name);
         builder.Build();
       }(),
       "Encountered duplicate flag name 'same' for message "
@@ -18,7 +18,7 @@ TEST(FlagsTest, DuplicateFlagName) {
 TEST(FlagsTest, DuplicateSucceed) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -40,7 +40,7 @@ TEST(FlagsTest, DuplicateSucceed) {
 TEST(FlagsTest, DuplicateConflict) {
   test::DuplicateFlagsDeath duplicates;
 
-  auto parser = stout::flags::Parser::Builder(&duplicates).Build();
+  auto parser = stout::flags::Parser::Builder(duplicates).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -72,7 +72,7 @@ TEST(FlagsTest, DuplicateConflict) {
 TEST(FlagsTest, DuplicateNonBooleanFlags) {
   test::DuplicateFlagsDeath duplicates;
 
-  auto parser = stout::flags::Parser::Builder(&duplicates).Build();
+  auto parser = stout::flags::Parser::Builder(duplicates).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/test/environment_variables.cc
+++ b/test/environment_variables.cc
@@ -22,7 +22,7 @@ int unsetenv(const char* env_name) {
 TEST(FlagsTest, EnvironmentVariableString) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST")
                     .Build();
 
@@ -51,7 +51,7 @@ TEST(FlagsTest, EnvironmentVariableString) {
 TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST_")
                     .Build();
 
@@ -83,7 +83,7 @@ TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
 TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST")
                     .Build();
 
@@ -113,7 +113,7 @@ TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
 TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .IncludeEnvironmentVariablesWithPrefix("STOUT_FLAGS_TEST_")
                     .Build();
 

--- a/test/environment_variables.cc
+++ b/test/environment_variables.cc
@@ -29,7 +29,6 @@ TEST(FlagsTest, EnvironmentVariableString) {
   std::array arguments = {
       "program",
       "--bar",
-      "one",
   };
 
   int argc = arguments.size();
@@ -44,10 +43,9 @@ TEST(FlagsTest, EnvironmentVariableString) {
   unsetenv(env_name);
 
   EXPECT_TRUE(flags.bar());
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags.foo());
   EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
 }
 
 TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
@@ -59,7 +57,6 @@ TEST(FlagsTest, IncludeEnvironmentVariableWithUnderscoreFailure) {
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -92,7 +89,6 @@ TEST(FlagsTest, EnvironmentVariableWithNoUnderlineInNameFailure) {
 
   std::array arguments = {
       "program",
-      "one",
   };
 
   int argc = arguments.size();
@@ -124,7 +120,6 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   std::array arguments = {
       "program",
       "--foo='hello'",
-      "one",
   };
 
   int argc = arguments.size();
@@ -138,9 +133,8 @@ TEST(FlagsTest, EnvironmentVariableWith2Underscores) {
   parser.Parse(&argc, &argv);
   unsetenv(env_name);
 
-  EXPECT_EQ(2, argc);
+  EXPECT_EQ(1, argc);
   EXPECT_EQ("'HELLO world'", flags._s());
   EXPECT_EQ("'hello'", flags.foo());
   EXPECT_EQ("program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
 }

--- a/test/help.cc
+++ b/test/help.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, Help) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/test/missing_flag_name.cc
+++ b/test/missing_flag_name.cc
@@ -23,3 +23,25 @@ TEST(FlagsTest, MissingFlagHelp) {
       "Missing flag 'help' for "
       "field 'test.MissingFlagHelp.s'");
 }
+
+TEST(FlagsTest, MissingSubcommandName) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithSubcommandMissingName flags;
+        auto builder = stout::flags::Parser::Builder(&flags);
+        builder.Build();
+      }(),
+      "Missing at least one subcommand name in 'names' for "
+      "field 'test.FlagsWithSubcommandMissingName.build'");
+}
+
+TEST(FlagsTest, MissingSubcommandHelp) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithSubcommandMissingHelp flags;
+        auto builder = stout::flags::Parser::Builder(&flags);
+        builder.Build();
+      }(),
+      "Missing subcommand 'help' for "
+      "field 'test.FlagsWithSubcommandMissingHelp.info_subcommand'");
+}

--- a/test/missing_flag_name.cc
+++ b/test/missing_flag_name.cc
@@ -6,7 +6,7 @@ TEST(FlagsTest, MissingFlagName) {
   EXPECT_DEATH(
       []() {
         test::MissingFlagName missing_flag_name;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_name);
+        auto builder = stout::flags::Parser::Builder(missing_flag_name);
         builder.Build();
       }(),
       "Missing at least one flag name in 'names' for "
@@ -17,7 +17,7 @@ TEST(FlagsTest, MissingFlagHelp) {
   EXPECT_DEATH(
       []() {
         test::MissingFlagHelp missing_flag_help;
-        auto builder = stout::flags::Parser::Builder(&missing_flag_help);
+        auto builder = stout::flags::Parser::Builder(missing_flag_help);
         builder.Build();
       }(),
       "Missing flag 'help' for "
@@ -28,7 +28,7 @@ TEST(FlagsTest, MissingSubcommandName) {
   EXPECT_DEATH(
       []() {
         test::FlagsWithSubcommandMissingName flags;
-        auto builder = stout::flags::Parser::Builder(&flags);
+        auto builder = stout::flags::Parser::Builder(flags);
         builder.Build();
       }(),
       "Missing at least one subcommand name in 'names' for "
@@ -39,7 +39,7 @@ TEST(FlagsTest, MissingSubcommandHelp) {
   EXPECT_DEATH(
       []() {
         test::FlagsWithSubcommandMissingHelp flags;
-        auto builder = stout::flags::Parser::Builder(&flags);
+        auto builder = stout::flags::Parser::Builder(flags);
         builder.Build();
       }(),
       "Missing subcommand 'help' for "

--- a/test/overload_parsing.cc
+++ b/test/overload_parsing.cc
@@ -9,7 +9,7 @@
 TEST(FlagsTest, DefaultOverloadParsingDuration) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .Build();
 
   std::array arguments = {
@@ -32,9 +32,9 @@ TEST(FlagsTest, DefaultOverloadParsingDuration) {
 TEST(FlagsTest, OverloadParsingDuration) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .OverloadParsing<google::protobuf::Duration>(
-                        [](const std::string& value, auto* duration) {
+                        [](const std::string& value, auto& duration) {
                           return std::optional<std::string>("unimplemented");
                         })
                     .Build();
@@ -64,13 +64,13 @@ TEST(FlagsTest, MultipleOverloadParsingDuration) {
   test::Flags flags;
 
   auto operation = [&flags]() {
-    auto parser = stout::flags::Parser::Builder(&flags)
+    auto parser = stout::flags::Parser::Builder(flags)
                       .OverloadParsing<google::protobuf::Duration>(
-                          [](const std::string& value, auto* duration) {
+                          [](const std::string& value, auto& duration) {
                             return std::optional<std::string>("unimplemented");
                           })
                       .OverloadParsing<google::protobuf::Duration>(
-                          [](const std::string& value, auto* duration) {
+                          [](const std::string& value, auto& duration) {
                             return std::optional<std::string>("unimplemented");
                           })
                       .Build();

--- a/test/parse.cc
+++ b/test/parse.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, ParseRequired) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -30,7 +30,7 @@ TEST(FlagsTest, ParseRequired) {
 TEST(FlagsTest, ParseStringWithSingleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -48,7 +48,7 @@ TEST(FlagsTest, ParseStringWithSingleQuotes) {
 TEST(FlagsTest, ParseStringWithDoubleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -66,7 +66,7 @@ TEST(FlagsTest, ParseStringWithDoubleQuotes) {
 TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -84,7 +84,7 @@ TEST(FlagsTest, ParseStringWithoutSingleOrDoubleQuotes) {
 TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -102,7 +102,7 @@ TEST(FlagsTest, ParseSpaceStringWithoutAnyQuotes) {
 TEST(FlagsTest, ParseImplicitBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -121,7 +121,7 @@ TEST(FlagsTest, ParseImplicitBoolean) {
 TEST(FlagsTest, ParseExplicitBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -140,7 +140,7 @@ TEST(FlagsTest, ParseExplicitBoolean) {
 TEST(FlagsTest, ParseNegatedBoolean) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -159,7 +159,7 @@ TEST(FlagsTest, ParseNegatedBoolean) {
 TEST(FlagsTest, ModifiedArgcArgv) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -183,7 +183,7 @@ TEST(FlagsTest, ModifiedArgcArgv) {
 TEST(FlagsTest, UnknownNonNegatedFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -208,7 +208,7 @@ TEST(FlagsTest, UnknownNonNegatedFlag) {
 TEST(FlagsTest, UnknownNegatedFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -233,7 +233,7 @@ TEST(FlagsTest, UnknownNegatedFlag) {
 TEST(FlagsTest, IncorrectNegatedBooleanFlag) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -259,7 +259,7 @@ TEST(FlagsTest, IncorrectNegatedBooleanFlag) {
 TEST(FlagsTest, NonBooleanFlagWithPrefix) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -285,7 +285,7 @@ TEST(FlagsTest, NonBooleanFlagWithPrefix) {
 TEST(FlagsTest, NonBooleanFlagWithEmptyValue) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",
@@ -311,7 +311,7 @@ TEST(FlagsTest, NonBooleanFlagWithEmptyValue) {
 TEST(FlagsTest, ProtobufTextFormatParserError) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "/path/to/program",

--- a/test/parse.cc
+++ b/test/parse.cc
@@ -164,9 +164,7 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   std::array arguments = {
       "/path/to/program",
       "--foo='hello world'",
-      "one",
       "--bar",
-      "two",
   };
 
   int argc = arguments.size();
@@ -177,11 +175,9 @@ TEST(FlagsTest, ModifiedArgcArgv) {
   EXPECT_TRUE(flags.bar());
   EXPECT_EQ("'hello world'", flags.foo());
 
-  EXPECT_EQ(3, argc);
+  EXPECT_EQ(1, argc);
 
   EXPECT_EQ("/path/to/program", argv[0]);
-  EXPECT_EQ("one", argv[1]);
-  EXPECT_EQ("two", argv[2]);
 }
 
 TEST(FlagsTest, UnknownNonNegatedFlag) {

--- a/test/subcommand_flags.cc
+++ b/test/subcommand_flags.cc
@@ -1,0 +1,360 @@
+#include <array>
+
+#include "gtest/gtest.h"
+#include "stout/flags.h"
+#include "test/test.pb.h"
+
+TEST(FlagsTest, MissingSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagsWithoutExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
+}
+
+TEST(FlagsTest, IncorrectSubcommandExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::FlagsWithIncorrectExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "stout.v1.subcommand option should be annotated on fields"
+      " that are only inside 'oneof subcommand'");
+}
+
+TEST(FlagsTest, IncorrectOneofName) {
+  EXPECT_DEATH(
+      []() {
+        test::IncorrectOneofName flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "'oneof' field must have 'subcommand' name. "
+      "Other names are illegal");
+}
+
+TEST(FlagsTest, SubcommandFlagExtension) {
+  EXPECT_DEATH(
+      []() {
+        test::SubcommandFlagExtension flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Every field of the 'oneof subcommand' must be"
+      " annotated with a stout.v1.subcommand option");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFields) {
+  EXPECT_DEATH(
+      []() {
+        test::DuplicateSubcommandFields flag;
+        auto builder = stout::flags::Parser::Builder(&flag);
+        builder.Build();
+      }(),
+      "Encountered duplicate subcommand name 'build'"
+      " for message 'test.DuplicateSubcommandFields'");
+}
+
+TEST(FlagsTest, SubcommandAndUnknownArguments) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+      "--",
+      "some",
+      "unknown",
+      "arguments",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(4, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("some", argv[1]);
+  EXPECT_EQ("unknown", argv[2]);
+  EXPECT_EQ("arguments", argv[3]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ(13, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_TRUE(flags.b());
+  EXPECT_EQ("hello world", flags.info_subcommand().info());
+}
+
+TEST(FlagsTest, DuplicateSubcommands) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "info_subcommand",
+      "--info=hello world",
+      "info_subcommand",
+      "--info=oops",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlags) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered duplicate flag 'other_flag'");
+}
+
+TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
+  test::DuplicateEnclosingFlagName flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--other_flag=1",
+      "build",
+      "--other_flag=2",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_build());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ(1, flags.other_flag());
+  EXPECT_EQ(2, flags.build().other_flag());
+}
+
+TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
+  test::SimpleSubcommandSucceed flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--b",
+      "build",
+      "--other_flag=1",
+      "info_subcommand",
+      "--info=hello",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  EXPECT_DEATH(
+      parser.Parse(&argc, &argv),
+      "Encountered unknown argument 'info_subcommand'");
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "build",
+      "--other_flag=1",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub1().has_build());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ(1, flags.sub1().build().other_flag());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub1",
+      "--another=Artur",
+      "--num=13",
+      "info_subcommand",
+      "--info=ciao",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub1());
+  EXPECT_FALSE(flags.has_sub2());
+  EXPECT_FALSE(flags.sub1().has_build());
+  EXPECT_TRUE(flags.sub1().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub1().another());
+  EXPECT_EQ(13, flags.sub1().num());
+  EXPECT_EQ("ciao", flags.sub1().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "info_subcommand",
+      "--info=some info",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_FALSE(flags.sub2().has_build());
+  EXPECT_TRUE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ("some info", flags.sub2().info_subcommand().info());
+}
+
+TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
+  test::ComplicatedSubcommandMessage flags;
+
+  auto parser = stout::flags::Parser::Builder(&flags).Build();
+
+  std::array arguments = {
+      "program",
+      "--flag=hello world",
+      "--other=Ben",
+      "sub2",
+      "--s=Artur",
+      "build",
+      "--other_flag=13",
+  };
+
+  int argc = arguments.size();
+  const char** argv = arguments.data();
+
+  parser.Parse(&argc, &argv);
+
+  EXPECT_TRUE(flags.has_sub2());
+  EXPECT_FALSE(flags.has_sub1());
+  EXPECT_TRUE(flags.sub2().has_build());
+  EXPECT_FALSE(flags.sub2().has_info_subcommand());
+  EXPECT_EQ(1, argc);
+  EXPECT_EQ("program", argv[0]);
+  EXPECT_EQ("hello world", flags.flag());
+  EXPECT_EQ("Ben", flags.other());
+  EXPECT_EQ("Artur", flags.sub2().s());
+  EXPECT_EQ(13, flags.sub2().build().other_flag());
+}

--- a/test/subcommand_flags.cc
+++ b/test/subcommand_flags.cc
@@ -8,7 +8,7 @@ TEST(FlagsTest, MissingSubcommandExtension) {
   EXPECT_DEATH(
       []() {
         test::SubcommandFlagsWithoutExtension flag;
-        auto builder = stout::flags::Parser::Builder(&flag);
+        auto builder = stout::flags::Parser::Builder(flag);
         builder.Build();
       }(),
       "Every field of the 'oneof subcommand' must be"
@@ -19,7 +19,7 @@ TEST(FlagsTest, IncorrectSubcommandExtension) {
   EXPECT_DEATH(
       []() {
         test::FlagsWithIncorrectExtension flag;
-        auto builder = stout::flags::Parser::Builder(&flag);
+        auto builder = stout::flags::Parser::Builder(flag);
         builder.Build();
       }(),
       "stout.v1.subcommand option should be annotated on fields"
@@ -30,7 +30,7 @@ TEST(FlagsTest, IncorrectOneofName) {
   EXPECT_DEATH(
       []() {
         test::IncorrectOneofName flag;
-        auto builder = stout::flags::Parser::Builder(&flag);
+        auto builder = stout::flags::Parser::Builder(flag);
         builder.Build();
       }(),
       "'oneof' field must have 'subcommand' name. "
@@ -41,7 +41,7 @@ TEST(FlagsTest, SubcommandFlagExtension) {
   EXPECT_DEATH(
       []() {
         test::SubcommandFlagExtension flag;
-        auto builder = stout::flags::Parser::Builder(&flag);
+        auto builder = stout::flags::Parser::Builder(flag);
         builder.Build();
       }(),
       "Every field of the 'oneof subcommand' must be"
@@ -52,7 +52,7 @@ TEST(FlagsTest, DuplicateSubcommandFields) {
   EXPECT_DEATH(
       []() {
         test::DuplicateSubcommandFields flag;
-        auto builder = stout::flags::Parser::Builder(&flag);
+        auto builder = stout::flags::Parser::Builder(flag);
         builder.Build();
       }(),
       "Encountered duplicate subcommand name 'build'"
@@ -62,7 +62,7 @@ TEST(FlagsTest, DuplicateSubcommandFields) {
 TEST(FlagsTest, SubcommandAndUnknownArguments) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -93,7 +93,7 @@ TEST(FlagsTest, SubcommandAndUnknownArguments) {
 TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -117,7 +117,7 @@ TEST(FlagsTest, SimpleSubcommandBuildSucceed) {
 TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -141,7 +141,7 @@ TEST(FlagsTest, SimpleSubcommandInfoSucceed) {
 TEST(FlagsTest, DuplicateSubcommands) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -163,7 +163,7 @@ TEST(FlagsTest, DuplicateSubcommands) {
 TEST(FlagsTest, DuplicateSubcommandFlags) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -184,7 +184,7 @@ TEST(FlagsTest, DuplicateSubcommandFlags) {
 TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
   test::DuplicateEnclosingFlagName flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -208,7 +208,7 @@ TEST(FlagsTest, DuplicateSubcommandFlagNameForEnclosingLevel) {
 TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
   test::SimpleSubcommandSucceed flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -230,7 +230,7 @@ TEST(FlagsTest, SubcommandFailSettingTwoOneofFlagsAtOnce) {
 TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
   test::ComplicatedSubcommandMessage flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -264,7 +264,7 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed1) {
 TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
   test::ComplicatedSubcommandMessage flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -298,7 +298,7 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed2) {
 TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
   test::ComplicatedSubcommandMessage flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",
@@ -330,7 +330,7 @@ TEST(FlagsTest, ComplicatedSubcommandSucceed3) {
 TEST(FlagsTest, ComplicatedSubcommandSucceed4) {
   test::ComplicatedSubcommandMessage flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags).Build();
+  auto parser = stout::flags::Parser::Builder(flags).Build();
 
   std::array arguments = {
       "program",

--- a/test/test.proto
+++ b/test/test.proto
@@ -4,6 +4,7 @@ package test;
 
 import "google/protobuf/duration.proto";
 import "stout/v1/flag.proto";
+import "stout/v1/subcommand.proto";
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -114,6 +115,312 @@ message DuplicateFlagsDeath {
       help: "help"
     }
   ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message BuildFlag {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message InfoFlag {
+  string info = 1 [
+    (stout.v1.flag) = {
+      names: [ "info" ]
+      help: "help"
+    }
+  ];
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithSubcommandMissingName {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithSubcommandMissingHelp {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagsWithoutExtension {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message FlagsWithIncorrectExtension {
+  bool b = 1 [
+    (stout.v1.subcommand) = {
+      names: [ "build" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message IncorrectOneofName {
+  oneof other {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandFlagExtension {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.flag) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SimpleSubcommandSucceed {
+  bool b = 1 [
+    (stout.v1.flag) = {
+      names: [ "b", "bb" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message ComplicatedSubcommandMessage {
+  string flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "flag" ]
+      help: "help"
+    }
+  ];
+
+  string other = 2 [
+    (stout.v1.flag) = {
+      names: [ "other" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    SubcommandSubMessage1 sub1 = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "sub1" ]
+        help: "help"
+      }
+    ];
+    SubcommandSubMessage2 sub2 = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "sub2" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage1 {
+  string another = 1 [
+    (stout.v1.flag) = {
+      names: [ "another" ]
+      help: "help"
+    }
+  ];
+
+  int32 num = 2 [
+    (stout.v1.flag) = {
+      names: [ "num" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 4 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message SubcommandSubMessage2 {
+  string s = 1 [
+    (stout.v1.flag) = {
+      names: [ "s" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateEnclosingFlagName {
+  int32 other_flag = 1 [
+    (stout.v1.flag) = {
+      names: [ "other_flag" ]
+      help: "help"
+    }
+  ];
+
+  oneof subcommand {
+    BuildFlag build = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info_subcommand = 3 [
+      (stout.v1.subcommand) = {
+        names: [ "info_subcommand" ]
+        help: "help"
+      }
+    ];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+message DuplicateSubcommandFields {
+  oneof subcommand {
+    BuildFlag build = 1 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+    InfoFlag info = 2 [
+      (stout.v1.subcommand) = {
+        names: [ "build" ]
+        help: "help"
+      }
+    ];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/validate.cc
+++ b/test/validate.cc
@@ -7,7 +7,7 @@
 TEST(FlagsTest, Validate) {
   test::Flags flags;
 
-  auto parser = stout::flags::Parser::Builder(&flags)
+  auto parser = stout::flags::Parser::Builder(flags)
                     .Validate(
                         "'bar' must be true",
                         [](const auto& flags) {


### PR DESCRIPTION
Created `subcommand.proto` with the message `Subcommand`. This message,
like `Flag` message in `stout/v1/flag.proto` is extended from
google.protobuf.FieldOptions message (google/protobuf/descriptor.proto).
Added the support for making sure that if someone gives some message
for "building" all of the (stout.v1.subcommand) will be inside `oneof
subcommand` field. Also added some tests.